### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Build binaries
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]


### PR DESCRIPTION
Potential fix for [https://github.com/About80Ninjas/concat/security/code-scanning/1](https://github.com/About80Ninjas/concat/security/code-scanning/1)

To fix the issue, we should explicitly declare a `permissions` block for the `build` job, restricting the GITHUB_TOKEN to the minimal privileges required. Since the `build` job only checks out code and uploads artifacts (and does not require write access to repository contents), `contents: read` is sufficient. Add the following block under the `build:` job and above `steps:`:

```yaml
permissions:
  contents: read
```

No code elsewhere in the workflow or repo needs to be modified, and no other imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
