### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Go CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/About80Ninjas/concat/security/code-scanning/2](https://github.com/About80Ninjas/concat/security/code-scanning/2)

To fix the flagged problem, add a `permissions` block to restrict the default permissions for the `GITHUB_TOKEN` used by this workflow/job. In this case, the workflow does not appear to need any write access; it only performs read operations (checkout code, set up Go, install dependencies, build, run tests). The minimal starting point provided by CodeQL is `contents: read`. This can be set either at the workflow root or within the `build-and-test` job; setting it at the workflow root applies to all jobs and is generally preferred unless jobs need distinct configs.

Specifically:
- Edit `.github/workflows/go.yml`.
- Add the following at the root (immediately after the workflow name and before `on:`):
  ```yaml
  permissions:
    contents: read
  ```

No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
