### PR TITLE
Fix: Handle 'dev' version in TestVersionFlag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Document changes in existing functionality here)
 
 ### Fixed
-- (Document bug fixes here)
+- TestVersionFlag now correctly handles 'dev' version string.
 
 ### Removed
 - (Document removals/deprecations here)

--- a/cmd/concat/main_test.go
+++ b/cmd/concat/main_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -126,7 +127,11 @@ func TestVersionFlag(t *testing.T) {
 	<-done
 
 	output := buf.String()
-	if !strings.Contains(output, "concat version") {
-		t.Errorf("expected version output, got %q", output)
+
+	// Updated regex pattern to match "concat version v0.0.0" format with optional pre-release suffixes
+	versionPattern := regexp.MustCompile(`concat version (?:v\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+)*|dev)`)
+
+	if !versionPattern.MatchString(output) {
+		t.Errorf("expected version output to match pattern 'concat version v0.0.0' (with optional pre-release suffix), got %q", output)
 	}
 }


### PR DESCRIPTION
The TestVersionFlag in cmd/concat/main_test.go was failing when the
 binary reported its version as dev. This occurs when the
 variable in the Makefile, which uses ,
evaluates to dev (e.g., in environments without git tags or with a dirty working directory).

This commit updates the regex pattern in TestVersionFlag to correctly handle dev as a valid version string, ensuring the test passes in such scenarios.

Updated CHANGELOG.md to reflect this fix.

# Pull Request

## Summary
<!-- Explain what this PR does and why -->

## Related Issue(s)
<!-- Link to related issue or task from TASKS.md -->
Closes #

## Changes
- [ ] Code changes
- [ x] Tests added/updated
- [ x] Documentation updated
- [ x] Changelog updated (`CHANGELOG.md` under [Unreleased])

### Details
<!-- Provide details on what was implemented (e.g., updated Makefile, added flag, refactored function) -->

## Checklist
Before submitting, please confirm:

- [ ] I created a **feature branch** from `main`.
- [ ] I ran `make build` successfully.
- [ ] I ran `make test` and all tests passed.
- [ ] I updated or added tests where needed.
- [ ] I updated relevant documentation/help text if needed.
- [ ] I updated **CHANGELOG.md** under `[Unreleased]` with this change.
- [ ] I followed the **Implementation Order** from `TASKS.md`.

## Screenshots / Logs
<!-- If applicable, paste terminal output, screenshots, or logs -->

## Additional Notes
<!-- Add anything else reviewers should know -->
